### PR TITLE
Remove fmt dependencies when build with SPDLOG_USE_STD_FORMAT flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Retrieved 2017-Oct-12 from https://github.com/github/gitignore/blob/master/R.gitignore
 # Licensed under CC0-1.0 https://github.com/github/gitignore/blob/master/LICENSE
 
+# VSCode
+.vscode 
+
 # History files
 .Rhistory
 .Rapp.history

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Retrieved 2017-Oct-12 from https://github.com/github/gitignore/blob/master/R.gitignore
 # Licensed under CC0-1.0 https://github.com/github/gitignore/blob/master/LICENSE
 
-# VSCode
-.vscode 
-
 # History files
 .Rhistory
 .Rapp.history
@@ -44,3 +41,6 @@ docs/mkdmt-src/docs
 
 # Emacs
 *~
+
+# VSCode
+.vscode 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-10-29 Xanthos Xanthopoulos <xanxanthopoulos@gmail.com>
+
+	* inst/include/rcpp_sink.h: Use spdlog::memory_buf_t as string when building under C++20 with SPDLOG_USE_STD_FORMAT
+	* inst/include/RcppSpdlog_types.h: Abort compilation if SPDLOG_USE_STD_FORMAT without C++20 or greater
+	* inst/include/spdl.h: Use std::vformat if SPDLOG_USE_STD_FORMAT flag is set
+	* src/formatter.cpp: Idem
+
 2024-10-13  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro release version

--- a/inst/include/RcppSpdlog_types.h
+++ b/inst/include/RcppSpdlog_types.h
@@ -1,6 +1,10 @@
 
 #pragma once
 
+#if defined(SPDLOG_USE_STD_FORMAT) && __cplusplus < 202002L
+#error SPDLOG_USE_STD_FORMAT should only be set when compiling with C++20 and greater
+#endif
+
 #include <Rcpp/Lightest>
 #if defined(RCPPSPDLOG_STOPWATCH_NO_FMT)
   #include <spdlog_stopwatch.h>	    	// spdlog::stopwatch without fmt header

--- a/inst/include/rcpp_sink.h
+++ b/inst/include/rcpp_sink.h
@@ -30,6 +30,7 @@ protected:
         spdlog::memory_buf_t formatted;
         spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
 
+        // When using C++20 with SPDLOG_USE_STD_FORMAT flag spdlog::memory_buf_t is an alias of std::string
         #ifdef SPDLOG_USE_STD_FORMAT
         Rcpp::Rcout << formatted;
         #else

--- a/inst/include/rcpp_sink.h
+++ b/inst/include/rcpp_sink.h
@@ -29,7 +29,12 @@ protected:
         // sending it to its final destination:
         spdlog::memory_buf_t formatted;
         spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+
+        #ifdef SPDLOG_USE_STD_FORMAT
+        Rcpp::Rcout << formatted;
+        #else
         Rcpp::Rcout << fmt::to_string(formatted);
+        #endif
     }
 
     void flush_() override {

--- a/inst/include/spdl.h
+++ b/inst/include/spdl.h
@@ -7,6 +7,10 @@
 // expose fmt::format via the courses in spdlog
 #include <spdlog/fmt/fmt.h>
 
+#ifdef SPDLOG_USE_STD_FORMAT
+#include <string_view>
+#endif
+
 // for convenience define cuter ones in another (shorter) namespace
 namespace spdl {
     inline void setup(const std::string& name = "default",
@@ -30,6 +34,26 @@ namespace spdl {
     // and many packages have opted into C++11 (or newer) but the check does not hurt
     #if __cplusplus >= 201103L
 
+    #ifdef SPDLOG_USE_STD_FORMAT 
+    template <typename... Args>
+    inline void trace(const char* fmt, Args&&... args ) { RcppSpdlog::log_trace(std::vformat(std::string_view(fmt), std::make_format_args(args...)).c_str()); }
+
+    template <typename... Args>
+    inline void debug(const char* fmt, Args&&... args ) { RcppSpdlog::log_debug(std::vformat(std::string_view(fmt), std::make_format_args(args...)).c_str()); }
+
+    template <typename... Args>
+    inline void info(const char* fmt, Args&&... args ) { RcppSpdlog::log_info(std::vformat(std::string_view(fmt), std::make_format_args(args...)).c_str()); }
+
+    template <typename... Args>
+    inline void warn(const char* fmt, Args&&... args ) { RcppSpdlog::log_warn(std::vformat(std::string_view(fmt), std::make_format_args(args...)).c_str()); }
+
+    template <typename... Args>
+    inline void error(const char* fmt, Args&&... args ) { RcppSpdlog::log_error(std::vformat(std::string_view(fmt), std::make_format_args(args...)).c_str()); }
+
+    template <typename... Args>
+    inline void critical(const char* fmt, Args&&... args ) { RcppSpdlog::log_critical(std::vformat(std::string_view(fmt), std::make_format_args(args...)).c_str()); }
+    
+    #else
     template <typename... Args>
     inline void trace(const char* fmt, Args&&... args ) { RcppSpdlog::log_trace(fmt::format(fmt, std::forward<Args>(args)... ).c_str()); }
 
@@ -47,7 +71,8 @@ namespace spdl {
 
     template <typename... Args>
     inline void critical(const char* fmt, Args&&... args ) { RcppSpdlog::log_critical(fmt::format(fmt, std::forward<Args>(args)... ).c_str()); }
-
+    #endif
+    
     #endif // if C++11
 
     inline Rcpp::XPtr<spdlog::stopwatch> stopwatch() { return RcppSpdlog::get_stopwatch(); }

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -3,19 +3,21 @@
 
 #include <RcppSpdlog>
 
-#ifdef SPDLOG_USE_STD_FORMAT
+#if defined(SPDLOG_USE_STD_FORMAT) && __cplusplus >= 202002L
+#define NAMESPACE std
+#else
+#define NAMESPACE fmt
+#endif
 
 template<std::size_t... S>
-std::format_args&& unpack_vector(const std::vector<std::string>& vec, std::index_sequence<S...>) {
-    return std::make_format_args(vec[S]...);
+NAMESPACE::format_args unpack_vector(const std::vector<std::string>& vec, std::index_sequence<S...>) {
+    return NAMESPACE::make_format_args(vec[S]...);
 }
 
 template<std::size_t size>
-std::format_args&& unpack_vector(const std::vector<std::string>& vec) {
+NAMESPACE::format_args unpack_vector(const std::vector<std::string>& vec) {
     return unpack_vector(vec, std::make_index_sequence<size>());
 }
-
-#endif
 
 //' Simple Pass-Through Formatter to \code{fmt::format()}
 //'
@@ -36,52 +38,27 @@ std::format_args&& unpack_vector(const std::vector<std::string>& vec) {
 // [[Rcpp::export]]
 std::string formatter(const std::string s, std::vector<std::string> v) {
     size_t n = v.size();
-    #ifdef SPDLOG_USE_STD_FORMAT
     switch (n) {
-        case 0: return std::vformat(std::string_view(s), std::make_format_args());
-        case 1: return std::vformat(std::string_view(s), unpack_vector<1>(v));
-        case 2: return std::vformat(std::string_view(s), unpack_vector<2>(v));
-        case 3: return std::vformat(std::string_view(s), unpack_vector<3>(v));
-        case 4: return std::vformat(std::string_view(s), unpack_vector<4>(v));
-        case 5: return std::vformat(std::string_view(s), unpack_vector<5>(v));
-        case 6: return std::vformat(std::string_view(s), unpack_vector<6>(v));
-        case 7: return std::vformat(std::string_view(s), unpack_vector<7>(v));
-        case 8: return std::vformat(std::string_view(s), unpack_vector<8>(v));
-        case 9: return std::vformat(std::string_view(s), unpack_vector<9>(v));
-        case 10: return std::vformat(std::string_view(s), unpack_vector<10>(v));
-        case 11: return std::vformat(std::string_view(s), unpack_vector<11>(v));
-        case 12: return std::vformat(std::string_view(s), unpack_vector<12>(v));
-        case 13: return std::vformat(std::string_view(s), unpack_vector<13>(v));
-        case 14: return std::vformat(std::string_view(s), unpack_vector<14>(v));
-        case 15: return std::vformat(std::string_view(s), unpack_vector<15>(v));
+        case 0: return NAMESPACE::vformat(NAMESPACE::string_view(s), NAMESPACE::make_format_args());
+        case 1: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<1>(v));
+        case 2: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<2>(v));
+        case 3: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<3>(v));
+        case 4: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<4>(v));
+        case 5: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<5>(v));
+        case 6: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<6>(v));
+        case 7: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<7>(v));
+        case 8: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<8>(v));
+        case 9: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<9>(v));
+        case 10: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<10>(v));
+        case 11: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<11>(v));
+        case 12: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<12>(v));
+        case 13: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<13>(v));
+        case 14: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<14>(v));
+        case 15: return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<15>(v));
         default: {
             Rcpp::warning("Only up to fifteen arguments support for now.");
-            return std::vformat(std::string_view(s), unpack_vector<12>(v));
+            return NAMESPACE::vformat(NAMESPACE::string_view(s), unpack_vector<12>(v));
         }
     }
-    #else
-    switch (n) {
-        case 0: return fmt::format(s);
-        case 1: return fmt::format(s, std::string(v[0]));
-        case 2: return fmt::format(s, std::string(v[0]), std::string(v[1]));
-        case 3: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]));
-        case 4: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]));
-        case 5: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]));
-        case 6: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]));
-        case 7: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]));
-        case 8: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]));
-        case 9: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]));
-        case 10: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]));
-        case 11: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]));
-        case 12: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]));
-        case 13: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]));
-        case 14: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]), std::string(v[13]));
-        case 15: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]), std::string(v[13]), std::string(v[14]));
-        default: {
-            Rcpp::warning("Only up to fifteen arguments support for now.");
-            return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]));
-        }
-    }
-#endif
 }
     

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -20,6 +20,47 @@
 //' @return A single (formatted) string
 //' @seealso https://github.com/fmtlib/fmt
 // [[Rcpp::export]]
+
+#ifdef SPDLOG_USE_STD_FORMAT
+
+template<std::size_t... S>
+std::format_args&& unpack_vector(const std::vector<std::string>& vec, std::index_sequence<S...>) {
+    return std::make_format_args(vec[S]...);
+}
+
+template<std::size_t size>
+std::format_args&& unpack_vector(const std::vector<std::string>& vec) {
+    return unpack_vector(vec, std::make_index_sequence<size>());
+}
+
+std::string formatter(const std::string s, std::vector<std::string> v) {
+    size_t n = v.size();
+    switch (n) {
+        case 0: return std::vformat(std::string_view(s), std::make_format_args());
+        case 1: return std::vformat(std::string_view(s), unpack_vector<1>(v));
+        case 2: return std::vformat(std::string_view(s), unpack_vector<2>(v));
+        case 3: return std::vformat(std::string_view(s), unpack_vector<3>(v));
+        case 4: return std::vformat(std::string_view(s), unpack_vector<4>(v));
+        case 5: return std::vformat(std::string_view(s), unpack_vector<5>(v));
+        case 6: return std::vformat(std::string_view(s), unpack_vector<6>(v));
+        case 7: return std::vformat(std::string_view(s), unpack_vector<7>(v));
+        case 8: return std::vformat(std::string_view(s), unpack_vector<8>(v));
+        case 9: return std::vformat(std::string_view(s), unpack_vector<9>(v));
+        case 10: return std::vformat(std::string_view(s), unpack_vector<10>(v));
+        case 11: return std::vformat(std::string_view(s), unpack_vector<11>(v));
+        case 12: return std::vformat(std::string_view(s), unpack_vector<12>(v));
+        case 13: return std::vformat(std::string_view(s), unpack_vector<13>(v));
+        case 14: return std::vformat(std::string_view(s), unpack_vector<14>(v));
+        case 15: return std::vformat(std::string_view(s), unpack_vector<15>(v));
+        default: {
+            Rcpp::warning("Only up to fifteen arguments support for now.");
+            return std::vformat(std::string_view(s), unpack_vector<12>(v));
+        }
+    }
+}
+
+#else
+
 std::string formatter(const std::string s, std::vector<std::string> v) {
     size_t n = v.size();
     switch (n) {
@@ -45,3 +86,5 @@ std::string formatter(const std::string s, std::vector<std::string> v) {
         }
     }
 }
+
+#endif


### PR DESCRIPTION
When building with SPDLOG_USE_STD_FORMAT spdlog hides the `fmt` dependency but rcppspdlog still tries to access the `fmt` library. This PR provides alternative implementation for these functions using the `<format>` library. Applicable only for C++20 and onwards.