### PR TITLE
Doc fix: remove duplicate \sQuote{warn} and re-document

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,13 +1,13 @@
+2024-10-13  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro release version
+
 2024-13-10  Contantinos Giachalis  <cgiachalis@outlook.com>
 
-  * src/interface.cpp (log_setup): Documentation fix for duplicate log level
-  
-  * man/log_setup.Rd: Idem
-  
-  * R/RcppExports.R: Idem
-	
-  * DESCRIPTION (RoxygenNote): Idem
-  
+	* src/interface.cpp (log_setup): Documentation fix for duplicate log level
+	* man/log_setup.Rd: Idem
+	* R/RcppExports.R: Idem
+
 2024-09-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Version 0.0.18

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2024-13-10  Contantinos Giachalis  <cgiachalis@outlook.com>
+
+  * src/interface.cpp (log_setup): Documentation fix for duplicate log level
+  
+  * man/log_setup.Rd: Idem
+  
+  * R/RcppExports.R: Idem
+	
+  * DESCRIPTION (RoxygenNote): Idem
+  
 2024-09-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Version 0.0.18

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppSpdlog
 Type: Package
 Title: R and C++ Interfaces to 'spdlog' C++ Header Library for Logging
-Version: 0.0.18
-Date: 2024-09-10
+Version: 0.0.18.1
+Date: 2024-10-13
 License: GPL (>= 2)
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
@@ -18,4 +18,4 @@ LinkingTo: Rcpp
 Imports: Rcpp
 Suggests: simplermarkdown
 VignetteBuilder: simplermarkdown
-RoxygenNote: 7.3.2
+RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ LinkingTo: Rcpp
 Imports: Rcpp
 Suggests: simplermarkdown
 VignetteBuilder: simplermarkdown
-RoxygenNote: 6.0.1
+RoxygenNote: 7.3.2

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -71,7 +71,7 @@ formatter <- function(s, v) {
 #' }
 #'
 #' Supported logging levels are, in order of increasing threshold values, \sQuote{trace},
-#' \sQuote{debug}, \sQuote{warn}, \sQuote{info}, \sQuote{warn}, \sQuote{error}, and
+#' \sQuote{debug}, \sQuote{info}, \sQuote{warn}, \sQuote{error}, and
 #' \sQuote{critical}.  A message issued below the current threshold is not displayed whereas
 #' a message at or above the current threshold is displayed.  The default level is \sQuote{warn}.
 #'

--- a/man/log_setup.Rd
+++ b/man/log_setup.Rd
@@ -74,7 +74,7 @@ Several functions are provided:
 }
 
 Supported logging levels are, in order of increasing threshold values, \sQuote{trace},
-\sQuote{debug}, \sQuote{warn}, \sQuote{info}, \sQuote{warn}, \sQuote{error}, and
+\sQuote{debug}, \sQuote{info}, \sQuote{warn}, \sQuote{error}, and
 \sQuote{critical}.  A message issued below the current threshold is not displayed whereas
 a message at or above the current threshold is displayed.  The default level is \sQuote{warn}.
 }

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -34,7 +34,7 @@ const std::string default_log_pattern = "[%Y-%m-%d %H:%M:%S.%e] [%n] [Process: %
 //' }
 //'
 //' Supported logging levels are, in order of increasing threshold values, \sQuote{trace},
-//' \sQuote{debug}, \sQuote{warn}, \sQuote{info}, \sQuote{warn}, \sQuote{error}, and
+//' \sQuote{debug}, \sQuote{info}, \sQuote{warn}, \sQuote{error}, and
 //' \sQuote{critical}.  A message issued below the current threshold is not displayed whereas
 //' a message at or above the current threshold is displayed.  The default level is \sQuote{warn}.
 //'


### PR DESCRIPTION
This is a documentation fix PR.

It removes the duplicate `\sQuote{warn}`  from docs.  You can inspect the change diff in the  `log_setup.Rd` below.