### PR TITLE
Explicitly use runtime format strings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-03-28  Xanthos Xanthopoulos  <xanxanthopoulos@gmail.com>
+
+	* inst/include/spdl.h: Wrap runtime format strings with 
+	`fmt::runtime`
+	* src/formatter.cpp: Idem
+
 2025-02-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Version 0.0.20

--- a/inst/include/spdl.h
+++ b/inst/include/spdl.h
@@ -55,22 +55,22 @@ namespace spdl {
     
     #else
     template <typename... Args>
-    inline void trace(const char* fmt, Args&&... args ) { RcppSpdlog::log_trace(fmt::format(fmt, std::forward<Args>(args)... ).c_str()); }
+    inline void trace(const char* fmt, Args&&... args ) { RcppSpdlog::log_trace(fmt::format(fmt::runtime(fmt), std::forward<Args>(args)... ).c_str()); }
 
     template <typename... Args>
-    inline void debug(const char* fmt, Args&&... args ) { RcppSpdlog::log_debug(fmt::format(fmt, std::forward<Args>(args)... ).c_str()); }
+    inline void debug(const char* fmt, Args&&... args ) { RcppSpdlog::log_debug(fmt::format(fmt::runtime(fmt), std::forward<Args>(args)... ).c_str()); }
 
     template <typename... Args>
-    inline void info(const char* fmt, Args&&... args ) { RcppSpdlog::log_info(fmt::format(fmt, std::forward<Args>(args)... ).c_str()); }
+    inline void info(const char* fmt, Args&&... args ) { RcppSpdlog::log_info(fmt::format(fmt::runtime(fmt), std::forward<Args>(args)... ).c_str()); }
 
     template <typename... Args>
-    inline void warn(const char* fmt, Args&&... args ) { RcppSpdlog::log_warn(fmt::format(fmt, std::forward<Args>(args)... ).c_str()); }
+    inline void warn(const char* fmt, Args&&... args ) { RcppSpdlog::log_warn(fmt::format(fmt::runtime(fmt), std::forward<Args>(args)... ).c_str()); }
 
     template <typename... Args>
-    inline void error(const char* fmt, Args&&... args ) { RcppSpdlog::log_error(fmt::format(fmt, std::forward<Args>(args)... ).c_str()); }
+    inline void error(const char* fmt, Args&&... args ) { RcppSpdlog::log_error(fmt::format(fmt::runtime(fmt), std::forward<Args>(args)... ).c_str()); }
 
     template <typename... Args>
-    inline void critical(const char* fmt, Args&&... args ) { RcppSpdlog::log_critical(fmt::format(fmt, std::forward<Args>(args)... ).c_str()); }
+    inline void critical(const char* fmt, Args&&... args ) { RcppSpdlog::log_critical(fmt::format(fmt::runtime(fmt), std::forward<Args>(args)... ).c_str()); }
     #endif
     
     #endif // if C++11

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,3 @@
 
 ## We need the spdlog headers
-PKG_CPPFLAGS =	-I../inst/include/ -std=c++20
+PKG_CPPFLAGS =	-I../inst/include/

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,3 @@
 
 ## We need the spdlog headers
-PKG_CPPFLAGS =	-I../inst/include/
+PKG_CPPFLAGS =	-I../inst/include/ -std=c++20

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -61,25 +61,25 @@ std::string formatter(const std::string s, std::vector<std::string> v) {
             return std::vformat(std::string_view(s), unpack_vector<12>(v));
         }
 #else
-        case 0: return fmt::format(s);
-        case 1: return fmt::format(s, std::string(v[0]));
-        case 2: return fmt::format(s, std::string(v[0]), std::string(v[1]));
-        case 3: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]));
-        case 4: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]));
-        case 5: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]));
-        case 6: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]));
-        case 7: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]));
-        case 8: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]));
-        case 9: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]));
-        case 10: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]));
-        case 11: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]));
-        case 12: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]));
-        case 13: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]));
-        case 14: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]), std::string(v[13]));
-        case 15: return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]), std::string(v[13]), std::string(v[14]));
+        case 0: return fmt::format(fmt::runtime(s));
+        case 1: return fmt::format(fmt::runtime(s), std::string(v[0]));
+        case 2: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]));
+        case 3: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]));
+        case 4: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]));
+        case 5: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]));
+        case 6: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]));
+        case 7: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]));
+        case 8: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]));
+        case 9: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]));
+        case 10: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]));
+        case 11: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]));
+        case 12: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]));
+        case 13: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]));
+        case 14: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]), std::string(v[13]));
+        case 15: return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]), std::string(v[12]), std::string(v[13]), std::string(v[14]));
         default: {
             Rcpp::warning("Only up to fifteen arguments support for now.");
-            return fmt::format(s, std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]));
+            return fmt::format(fmt::runtime(s), std::string(v[0]), std::string(v[1]), std::string(v[2]), std::string(v[3]), std::string(v[4]), std::string(v[5]), std::string(v[6]), std::string(v[7]), std::string(v[8]), std::string(v[9]), std::string(v[10]), std::string(v[11]));
         }
 #endif
     }


### PR DESCRIPTION
When compiling with C++20 `fmt::format` expects a string literal or a `constexpr` string. Both `const char*` and `std::string` are erroring out during compile time in such context. Wrapping the with `fmt::runtime` enables the use of them as format strings.